### PR TITLE
Fix task "All" filter

### DIFF
--- a/thetatauCMT/tasks/filters.py
+++ b/thetatauCMT/tasks/filters.py
@@ -12,7 +12,7 @@ class TaskListFilter(django_filters.FilterSet):
         choices=(
             ("1", "Complete"),
             ("0", "Incomplete"),
-            ("", "All"),
+            ("A", "All"),
         ),
     )
     date = DateRangeFilter(field_name="date")
@@ -28,7 +28,7 @@ class TaskListFilter(django_filters.FilterSet):
         order_by = ["date"]
 
     def filter_complete(self, queryset, field_name, value):
-        if value:
+        if value and value != "A":
             chapter = self.request.user.current_chapter
             queryset = queryset.annotate(
                 complete_result=models.Case(


### PR DESCRIPTION
#### Issue
When viewing chapter tasks, if I set the filter to "All", I expect all tasks, the filter resets itself to "Incomplete", and I can only see the chapter's incomplete tasks

I expect the "All" filter not to reset, and to show all tasks, regardless of completion

#### Cause
The view request sets the task complete filter to filter on incomplete tasks by default. I believe this was meant to set a default filter on the empty `-----` option

The view requested filtered on "All" is the same as the view request filtered on nothing `-----`. The system mistakenly thinks that there is no filter set and, defaults to "Incomplete"

#### Solution
Ensure that the "All" filter has a non-empty filter value in the request. This ensures that the system does not use the default. Make sure that this new "filter on all" request skips the task completion filter when getting results

#### UI Results
##### Incomplete
Unchanged
![Screenshot 2025-05-10 at 11 52 01 AM](https://github.com/user-attachments/assets/9c82e62e-e4dd-43d8-9f77-7d8a760b5da7)


##### Complete
Unchanged
![Screenshot 2025-05-10 at 11 52 09 AM](https://github.com/user-attachments/assets/b1552e16-cb36-4add-a5f9-55c372416766)

##### All
Now contains both incomplete *and* complete tasks
![Screenshot 2025-05-10 at 11 52 23 AM](https://github.com/user-attachments/assets/89cc8064-5fb1-41d3-bdb7-b08847e74c33)

Note that the blank `-----` option still defaults to incomplete