### PR TITLE
ci: Add Renovate to keep container images and pip build backends current

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "docker:pinDigests",
+    ":semanticCommitTypeAll(chore)"
+  ],
+  "enabledManagers": [
+    "dockerfile",
+    "docker-compose",
+    "custom.regex"
+  ],
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)Dockerfile$/"
+      ],
+      "matchStrings": [
+        "\"(?<depName>setuptools|wheel|poetry-core)==(?<currentValue>[0-9][0-9.]*)\""
+      ],
+      "datasourceTemplate": "pypi",
+      "versioningTemplate": "pep440"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["dockerfile", "docker-compose"],
+      "groupName": "base images",
+      "commitMessageTopic": "base image {{depName}}"
+    },
+    {
+      "matchManagers": ["dockerfile", "docker-compose"],
+      "matchUpdateTypes": ["digest", "pinDigest"],
+      "groupName": "base image digests"
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchDatasources": ["pypi"],
+      "groupName": "docker build backends"
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["setuptools"],
+      "allowedVersions": "<81"
+    }
+  ]
+}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,45 @@
+name: Renovate
+
+on:
+  schedule:
+    # Monday at 06:00 UTC
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Renovate log level"
+        required: false
+        default: "info"
+      dryRun:
+        description: "Dry run (no branches/PRs)"
+        required: false
+        default: "false"
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code Repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@5402b206248e5a8c8427a15102702eb9c1793efc # v46.2.4
+        with:
+          configurationFile: .github/renovate.json
+          # Personal access token or GitHub App token with repo + PR write scope,
+          # stored as a repository/organization secret.
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
+          RENOVATE_DRY_RUN: ${{ inputs.dryRun == 'true' && 'full' || '' }}
+          RENOVATE_AUTODISCOVER: "false"
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_ONBOARDING: "false"
+          RENOVATE_PLATFORM: github

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -26,6 +26,15 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
+      # Mint a short-lived installation token for the self-hosted Renovate
+      # GitHub App from its App ID + private key (stored as secrets).
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
+
       - name: Checkout Code Repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
@@ -33,9 +42,7 @@ jobs:
         uses: renovatebot/github-action@5402b206248e5a8c8427a15102702eb9c1793efc # v46.2.4
         with:
           configurationFile: .github/renovate.json
-          # Personal access token or GitHub App token with repo + PR write scope,
-          # stored as a repository/organization secret.
-          token: ${{ secrets.RENOVATE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
           RENOVATE_DRY_RUN: ${{ inputs.dryRun == 'true' && 'full' || '' }}
@@ -43,3 +50,5 @@ jobs:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_ONBOARDING: "false"
           RENOVATE_PLATFORM: github
+          # renovatebot/github-action derives the bot username and git author
+          # from the app token automatically; no need to set them here.


### PR DESCRIPTION
Depends on #1138 (container image + GitHub Actions pinning).

## What

Adds a self-hosted Renovate setup that opens PRs to bump the pinned Docker image
digests and the pinned pip build backends. It complements Dependabot, which
keeps owning GitHub Actions and pip security updates. There is no overlap between
the two.

## Why

The previous PR pinned every container image to an exact digest. A digest cannot
be swapped under us by an upstream retag, and two builds a month apart now
produce the same image.

This PR adds that maintenance path. Renovate watches for newer digests and opens
an ordinary pull request when one is available, so a base image update becomes a
reviewed, deliberate change, the same as any other PR. It is not auto-merged.

## Files

**`.github/renovate.json`**
- `enabledManagers`: `dockerfile`, `docker-compose`, `custom.regex` only.
  Renovate does not touch GitHub Actions or `requirements/*.txt`.
- `docker:pinDigests`: keeps every image reference digest pinned.
- `minimumReleaseAge: "3 days"` with `internalChecksFilter: "strict"`: an update
  PR is only raised once the new image or digest is at least 3 days old.
- A custom regex manager tracks `setuptools`, `wheel`, and `poetry-core` in the
  Dockerfiles, with `setuptools` held to `<81` to match `requirements/base.txt`.
- Commits use the `chore` semantic type.
- Package rules group updates as "base images", "base image digests", and
  "docker build backends".

**`.github/workflows/renovate.yml`**
- Runs Mondays at 06:00 UTC, plus manual `workflow_dispatch` (`logLevel` and
  `dryRun` inputs).
- Generates a short-lived token from a self-hosted Renovate GitHub App
  (`actions/create-github-app-token`), then runs `renovatebot/github-action`.
  All three actions are pinned to commit SHAs.
- Self-hosted mode: autodiscover off, repository pinned to this repo, onboarding
  off (the config lives in-repo).
- `concurrency` guard so runs never overlap.

## Required setup before Renovate can run

Someone with **org owner** access to `ThetaTau` (and repo admin on `CMT`) needs
to do the following once. Until then the scheduled run fails at the
"Generate app token" step and nothing else is affected.

### 1. Create the GitHub App

Go to `https://github.com/organizations/ThetaTau/settings/apps` and click
**New GitHub App**.

- **GitHub App name:** `ThetaTau CMT Renovate` (must be globally unique)
- **Homepage URL:** `https://github.com/ThetaTau/CMT` (any valid URL is fine)
- **Webhook:** untick **Active** (Renovate polls, it does not use webhooks)
- **Repository permissions:**
  - **Contents:** Read and write  (create branches and commits)
  - **Pull requests:** Read and write  (open and update PRs)
  - **Metadata:** Read-only  (selected automatically)
  - leave everything else as **No access**
- **Where can this GitHub App be installed?** Only on this account

Click **Create GitHub App**.

### 2. Generate a private key

On the new app's page, scroll to **Private keys** and click
**Generate a private key**. A `.pem` file downloads. Keep it safe; it cannot be
re-downloaded (you can only generate a new one).

### 3. Note the App ID

On the app's **General** page, near the top, copy the numeric **App ID**
(for example `123456`).

### 4. Install the app on the repo

In the app's left sidebar click **Install App**, choose the **ThetaTau**
account, select **Only select repositories**, pick **CMT**, and click
**Install**.

### 5. Add the two Actions secrets

In `ThetaTau/CMT` go to
**Settings > Secrets and variables > Actions > New repository secret** and add:

| Name | Value |
|---|---|
| `RENOVATE_APP_ID` | the numeric App ID from step 3 |
| `RENOVATE_APP_PRIVATE_KEY` | the entire contents of the `.pem` file, including the `-----BEGIN` and `-----END` lines |

### 6. Verify

Run the workflow manually: **Actions > Renovate > Run workflow**, with
**Dry run** set to `true`. A green run that logs the dependencies it found and
says it would open PRs confirms the setup. Set dry run back to `false` (or just
let the Monday schedule take over) to let it open real PRs.

## Notes

- The weekly cron only starts firing once this is merged to the default branch.
- Best merged after the image and Actions pinning PR, so Renovate maintains the
  existing pins rather than opening a batch of PRs to create them.
- `actionlint` passes on the workflow and `renovate-config-validator` passes on
  the config.
