### PR TITLE
ci: Add Semgrep security scan on pull requests

### DIFF
--- a/.github/semgrep/cmt.yml
+++ b/.github/semgrep/cmt.yml
@@ -1,0 +1,57 @@
+# CMT-specific Semgrep rules. Runs alongside the registry packs listed in
+# .github/workflows/pr-security.yml. Diff-aware on PRs, so these only fire on
+# newly added/changed matches. Escape hatch: `# nosemgrep: <rule-id> -- reason`.
+rules:
+  - id: cmt-no-eval
+    languages: [python]
+    severity: ERROR
+    message: >-
+      eval()/exec() is banned in CMT. For score/meeting formulas use a safe
+      evaluator (simpleeval, asteval) or an explicit parser. If this is
+      unavoidable, annotate with `# nosemgrep: cmt-no-eval -- <reason>`.
+    pattern-either:
+      - pattern: eval(...)
+      - pattern: exec(...)
+    paths:
+      exclude:
+        - "*/tests/*"
+        - "*/migrations/*"
+
+  - id: cmt-no-new-csrf-exempt
+    languages: [python]
+    severity: ERROR
+    message: >-
+      New @csrf_exempt view. CSRF exemptions must be justified in review
+      (inbound webhook with signature verification, etc.). Confirm the endpoint
+      authenticates the caller some other way, then annotate with
+      `# nosemgrep: cmt-no-new-csrf-exempt -- <reason>`.
+    pattern-either:
+      - pattern: |
+          @csrf_exempt
+          def $F(...):
+            ...
+      - pattern: |
+          @method_decorator(csrf_exempt, ...)
+          class $C(...):
+            ...
+      - pattern: method_decorator(csrf_exempt, ...)
+    paths:
+      exclude:
+        - "*/tests/*"
+
+  - id: cmt-mark-safe-nonliteral
+    languages: [python]
+    severity: ERROR
+    message: >-
+      mark_safe() called on a non-literal value — this is the stored-XSS shape.
+      Sanitize with nh3 first, or build the HTML with format_html()/django.utils.html.
+      If the input is provably trusted, annotate with
+      `# nosemgrep: cmt-mark-safe-nonliteral -- <reason>`.
+    patterns:
+      - pattern: mark_safe($X)
+      - pattern-not: mark_safe("...")
+      - pattern-not: mark_safe(f"...")
+    paths:
+      exclude:
+        - "*/tests/*"
+        - "*/migrations/*"

--- a/.github/workflows/pr-security.yml
+++ b/.github/workflows/pr-security.yml
@@ -1,0 +1,65 @@
+name: PR Security
+
+on:
+  pull_request:
+    branches: ["main", "staging"]
+
+concurrency:
+  group: pr-security-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    name: Semgrep
+    runs-on: ubuntu-latest
+
+    # Dependabot/Renovate branches only touch dependency manifests, not app code.
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          # semgrep ci needs history to compute the PR diff baseline (merge base).
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Semgrep
+        # Pinned for reproducible rule/engine behavior; bump deliberately.
+        run: pip install --quiet "semgrep==1.175.0"
+
+      - name: Run Semgrep
+        # `semgrep ci` on a pull_request event is diff-aware: it reports only
+        # findings introduced vs. the merge base, never pre-existing ones.
+        # continue-on-error so semgrep's exit code doesn't decide the gate;
+        # the "Gate" step below does.
+        continue-on-error: true
+        run: semgrep ci --json-output=semgrep.json
+        env:
+          SEMGREP_SEND_METRICS: "off"
+          # No Semgrep AppSec Platform token, so rules come from the registry
+          # via SEMGREP_RULES (space/newline separated) plus the local pack.
+          SEMGREP_RULES: >-
+            p/django
+            p/python
+            p/security-audit
+            p/secrets
+            p/dockerfile
+            p/github-actions
+            .github/semgrep/
+
+      - name: Gate on new ERROR findings
+        run: |
+          count=$(python -c "import json; print(sum(1 for r in json.load(open('semgrep.json'))['results'] if r['extra']['severity'] == 'ERROR'))")
+          echo "New ERROR-severity findings in this diff: $count"
+          if [ "$count" -gt 0 ]; then
+            echo "::error::Semgrep found $count new ERROR-severity issue(s) in this PR's diff. See the run log / annotations above."
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,49 @@
 5. Work on issue, finish issue
 6. Submit pull request
 
+## Security checks on pull requests
+
+Every PR into `main` or `staging` runs [Semgrep](https://semgrep.dev), a static
+analysis tool that looks for known-risky code patterns.
+
+It is **diff-aware**: it only looks at the lines your PR changed. Pre-existing
+issues elsewhere in the codebase will not block your PR. Your check fails only if
+your diff introduces a new **ERROR-severity** finding. Lower-severity findings
+show up as comments on the "Files changed" tab but do not block.
+
+On top of the standard Django/Python rule sets, this repo has three of its own
+(in `.github/semgrep/cmt.yml`):
+
+- **`cmt-no-eval`**: no new `eval()` / `exec()`. Use a real parser or a safe
+  evaluator instead.
+- **`cmt-no-new-csrf-exempt`**: a new `@csrf_exempt` view must be justified
+  (inbound webhook with signature verification, etc.).
+- **`cmt-mark-safe-nonliteral`**: do not call `mark_safe()` on a variable;
+  sanitize with `nh3` or build the HTML with `format_html()`.
+
+### Bypassing a finding
+
+If a finding is a false positive or the pattern is genuinely safe in context,
+add a `nosemgrep` comment **on the flagged line** with a short reason:
+
+```python
+result = eval(formula)  # nosemgrep: cmt-no-eval -- formula is an admin-only config value, validated on save
+```
+
+The comment is visible in code review, so a reviewer sees the justification. Use
+it sparingly; "make the check pass" is not a reason.
+
+### Running it locally (optional)
+
+Scan with the same rules the CI uses:
+
+```
+docker run --rm -v "$PWD:/src" -w /src semgrep/semgrep \
+  semgrep scan --config .github/semgrep/ --config p/django --config p/python
+```
+
+Or install Semgrep (`pipx install semgrep`) and drop the `docker run ...` prefix.
+
 Following 2 scoops of Django - https://www.feldroy.com/products/two-scoops-of-django-3-x
 
 Entire structure based on Cookie Cutter Django: https://github.com/pydanny/cookiecutter-django


### PR DESCRIPTION
## What

Adds a Semgrep static-analysis check that runs on every pull request into `main`
or `staging`. It is **diff-aware**: it only flags problems introduced by the PR,
and it **fails the check only on new ERROR-severity findings**. Pre-existing
issues in untouched code never block anything.


## Why

The codebase has never had automated security linting. A quick scan turns up the
shapes you would expect in a Django app of this age: `eval()` on a formula string
pulled from the database `scores/models.py`, `events/models.py`, 8 `@csrf_exempt`
views, and ~25 `mark_safe()` calls on non-literal values. Note that info was from 
a scan of main

Its probably work to fix all of that if it even needs to be fixed but we can stop
those patterns from being introduced in the future.

## Files

**`.github/workflows/pr-security.yml`**
- Triggers on `pull_request` into `main` or `staging`. Skips Dependabot/Renovate
  branches (they only touch dependency manifests).
- Installs a pinned Semgrep (`1.175.0`) and runs `semgrep ci`.
- Rules come from the public registry (no Semgrep account or token needed):
  `p/django`, `p/python`, `p/security-audit`, `p/secrets`, `p/dockerfile`,
  `p/github-actions`, plus the local pack below.
- A "Gate" step parses the results and fails the job only if the diff introduces
  one or more **ERROR-severity** findings. WARNING/INFO show as inline PR
  annotations but do not block.
- No results are sent to the GitHub Security tab, to Semgrep, or anywhere else;
  the JSON report lives only on the runner for the duration of the run.
- `actions/checkout` and `actions/setup-python` are pinned to commit SHAs.

**`.github/semgrep/cmt.yml`** — three project-specific rules, all `severity: ERROR`:

| Rule | Fires on |
|---|---|
| `cmt-no-eval` | any new `eval(...)` or `exec(...)` outside tests/migrations |
| `cmt-no-new-csrf-exempt` | a newly added `@csrf_exempt` view |
| `cmt-mark-safe-nonliteral` | `mark_safe(x)` where `x` is not a string literal |

Escape hatch for a justified case: `# nosemgrep: <rule-id> -- reason` on the line,
which is visible in review.

## Behavior on the existing backlog

A full scan currently reports ~35 findings from the three local rules (25
`mark_safe`, 8 `csrf_exempt`, 2 `eval`). All are in existing code, so the
diff-aware PR scan will not block on any of them. They can be worked down
separately.

## Notes

- The `semgrep==1.175.0` pin is maintained by hand for now (neither Dependabot
  nor the Renovate config tracks a version inside a `pip install` line). A
  follow-up could hoist it into a requirements file.
- `actionlint` passes on the workflow and `semgrep --validate` passes on the
  rules file.
