### PR TITLE
fix(tests): Fix two pre-existing test failures on main

### DIFF
--- a/thetatauCMT/forms/tests/test_notifications.py
+++ b/thetatauCMT/forms/tests/test_notifications.py
@@ -78,12 +78,12 @@ def test_email_rmp_signed_to_emails_contains_user_email():
 
 
 @pytest.mark.django_db
-def test_email_rmp_signed_cc_contains_cmt():
+def test_email_rmp_signed_has_no_cc():
     from thetatauCMT.users.tests.factories import UserFactory
 
     user = UserFactory.create()
     notif = EmailRMPSigned(user, b"", "rmp.pdf")
-    assert "cmt@thetatau.org" in notif.cc
+    assert notif.cc == []
 
 
 @pytest.mark.django_db

--- a/thetatauCMT/guides/tests/test_role_guides.py
+++ b/thetatauCMT/guides/tests/test_role_guides.py
@@ -16,6 +16,7 @@ from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils import timezone
 
+from thetatauCMT.chapters.tests.factories import ChapterFactory
 from thetatauCMT.guides import services
 from thetatauCMT.guides.models import Audience, FeatureArea, RoleGuide
 from thetatauCMT.guides.tests.factories import FeatureFactory, RoleGuideFactory, RoleGuideStepFactory
@@ -49,10 +50,14 @@ def _member():
     return UserFactory(status="active")
 
 
-def _officer(*roles):
+def _officer(*roles, chapter=None):
     user = _in_group(_member(), "officer")
+    fields = ["current_roles"]
+    if chapter is not None:
+        user.chapter = chapter
+        fields.append("chapter")
     user.current_roles = list(roles) or ["treasurer"]
-    user.save(update_fields=["current_roles"])
+    user.save(update_fields=fields)
     return user
 
 
@@ -190,8 +195,8 @@ def test_another_chapters_completion_does_not_close_out_mine():
     Worth pinning down, because it is the one place a guide could quietly tell an
     officer they are done when they are not.
     """
-    mine = _officer("treasurer")
-    theirs = _officer("treasurer")
+    mine = _officer("treasurer", chapter=ChapterFactory(name="alpha", school_type="semester"))
+    theirs = _officer("treasurer", chapter=ChapterFactory(name="beta", school_type="semester"))
     guide = RoleGuideFactory(role="treasurer")
     task = _task("treasurer", "Shared obligation", mine.current_chapter)
     TaskChapter.objects.create(task=task.dates.first(), chapter=theirs.current_chapter, date=timezone.now())


### PR DESCRIPTION
## What

Fixes the two tests currently failing on `main`. Both failures predate this
branch:

- `test_email_rmp_signed_cc_contains_cmt` broke in `a8e2fb32` 
- `test_another_chapters_completion_does_not_close_out_mine` was added in
  `a2c354c8` and has failed every run on the ci since.

No production code changes; test files only.

## Fix 1: stale RMP-signed CC assertion

`a8e2fb32` intentionally changed `EmailRMPSigned` to stop CC'ing
`cmt@thetatau.org` (`self.cc = []`), but the test still asserted the CC was
present.

Inverted it to assert `notif.cc == []` and renamed it to
`test_email_rmp_signed_has_no_cc`, so it now documents the intended behavior and
guards against the CC silently returning.

## Fix 2: ChapterFactory name collision

`test_another_chapters_completion_does_not_close_out_mine` needs two officers in
two different chapters. Each officer is built through `_officer()` ->
`UserFactory` -> `ChapterFactory`, and `ChapterFactory` sets `name` from
`Faker("random_element", elements=GREEK_ABR.values())` (a random pick from ~55
names) with `django_get_or_create = ("name",)`.

When the two random picks land on the same name, `get_or_create` returns the
*same* chapter row for both officers. The test then marks the task complete for
"theirs" chapter, which is also "mine" chapter, and the assertion that the item
is still open for "mine" fails.

It fails on every CI run rather than randomly because the suite runs in a fixed
order, so the RNG state when this test runs is deterministic, and in the
full-suite run those two picks happen to be equal. Run the test alone and it
passes (different RNG state).

Added an optional `_officer(*roles, chapter=None)` argument and pass two
explicitly named chapters (`alpha`, `beta`) in this test, so the two rows are
always distinct. Both chapters are pinned to `school_type="semester"` so the
second assertion exercises the completion filter rather than a school-type
mismatch.

`ChapterFactory` itself is unchanged; it is used in ~50 files. One thing to note 
when testing locally with make test it used all the workers my computer can handle
which is 20 and it was not failing. Since that is CPU bound and the runners are always 4
cores it failed every time. Might need to look into other things in the test suite to either
enforce the same number of workers when running locally or some other workaround. 

## Verification

- Both tests pass individually and in the full `thetatauCMT/guides/` and
  `thetatauCMT/forms/` runs.
- `black` passes; the new import is isort-ordered.
