### PR TITLE
feat(users): Sync username with new email when new primary email is set

### DIFF
--- a/thetatauCMT/users/models.py
+++ b/thetatauCMT/users/models.py
@@ -404,6 +404,12 @@ class User(AbstractUser, EmailSignalMixin):
     )
     history = HistoricalRecords()
 
+    @classmethod
+    def from_db(cls, db, field_names, values):
+        instance = super().from_db(db, field_names, values)
+        instance._loaded_email = instance.email
+        return instance
+
     def save(self, *args, **kwargs):
         suffix = f" {self.suffix}" if self.suffix else ""
         if self.name == "":
@@ -412,7 +418,26 @@ class User(AbstractUser, EmailSignalMixin):
             self.name = f"{self.preferred_name} {self.last_name}{suffix}"
         if self.username == "":
             self.username = self.email
+        else:
+            self._sync_username_to_email(kwargs)
         super(User, self).save(*args, **kwargs)
+
+    def _sync_username_to_email(self, save_kwargs):
+        loaded_email = getattr(self, "_loaded_email", None)
+        if (
+            not self.pk
+            or not self.email
+            or self.username != loaded_email
+            or self.email == self.username
+            or len(self.email) > 150
+        ):
+            return
+        if User.objects.exclude(pk=self.pk).filter(username=self.email).exists():
+            return
+        self.username = self.email
+        update_fields = save_kwargs.get("update_fields")
+        if update_fields is not None and "username" not in update_fields:
+            save_kwargs["update_fields"] = [*update_fields, "username"]
 
     def __str__(self):
         return self.name

--- a/thetatauCMT/users/tests/test_auth_flows.py
+++ b/thetatauCMT/users/tests/test_auth_flows.py
@@ -231,3 +231,25 @@ def test_account_adapter_2fa_methods_exist_on_instance(rf):
     assert callable(adapter.has_2fa_enabled)
     assert hasattr(adapter, "get_2fa_authenticate_url")
     assert callable(adapter.get_2fa_authenticate_url)
+
+
+@pytest.mark.django_db
+def test_make_primary_email_via_account_email_view_syncs_username(auto_login_user):
+    from allauth.account.models import EmailAddress
+
+    client, user = auto_login_user()
+    original = user.email
+    assert user.username == original
+
+    EmailAddress.objects.create(user=user, email=original, verified=True, primary=True)
+    EmailAddress.objects.create(user=user, email="newprimary@example.edu", verified=True, primary=False)
+
+    response = client.post(
+        reverse("account_email"),
+        {"action_primary": "", "email": "newprimary@example.edu"},
+    )
+    assert response.status_code in (200, 302)
+
+    user.refresh_from_db()
+    assert user.email == "newprimary@example.edu"
+    assert user.username == "newprimary@example.edu"

--- a/thetatauCMT/users/tests/test_models.py
+++ b/thetatauCMT/users/tests/test_models.py
@@ -95,6 +95,7 @@ from thetatauCMT.users.models import (  # noqa: E402
     CONTACT_VISIBILITY_MEMBERS,
     CONTACT_VISIBILITY_NO_ONE,
     CONTACT_VISIBILITY_OFFICERS,
+    User,
 )
 from thetatauCMT.users.tests.factories import UserFactory  # noqa: E402
 
@@ -337,3 +338,47 @@ def test_hiding_both_toggles_without_role_is_a_plain_member():
     assert user.is_officer_group is False
     assert user.chapter_officer() == set()
     assert user_is_national_officer(user) is False
+
+
+@pytest.mark.django_db
+def test_changing_email_syncs_username():
+    UserFactory(email="old@example.edu")
+    user = User.objects.get(username="old@example.edu")
+    user.email = "new@example.edu"
+    user.save()
+    assert user.username == "new@example.edu"
+    assert User.objects.get(pk=user.pk).username == "new@example.edu"
+
+
+@pytest.mark.django_db
+def test_changing_email_leaves_a_customised_username_alone():
+    UserFactory(email="member@example.edu", username="legacy-handle")
+    user = User.objects.get(username="legacy-handle")
+    user.email = "member2@example.edu"
+    user.save()
+    assert user.username == "legacy-handle"
+
+
+@pytest.mark.django_db
+def test_email_change_colliding_with_another_username_is_skipped():
+    UserFactory(email="taken@example.edu")
+    UserFactory(email="mine@example.edu")
+    user = User.objects.get(username="mine@example.edu")
+    user.email = "taken@example.edu"
+    user.save()  # must not raise IntegrityError
+    assert user.username == "mine@example.edu"
+
+
+@pytest.mark.django_db
+def test_email_change_via_update_fields_persists_username():
+    UserFactory(email="a@example.edu")
+    user = User.objects.get(username="a@example.edu")
+    user.email = "b@example.edu"
+    user.save(update_fields=["email"])
+    assert User.objects.get(pk=user.pk).username == "b@example.edu"
+
+
+@pytest.mark.django_db
+def test_new_user_still_takes_username_from_email():
+    user = UserFactory(username="", email="fresh@example.edu")
+    assert user.username == "fresh@example.edu"


### PR DESCRIPTION
Closes #239

## What

When a member changes their email, `User.username` now follows it, so
`username == email` stays true after the change, not just at account creation.

## Why

Several places look a user up by treating their email as the username:

- `chapters/views.py` -> `User.objects.get(username=form.instance.email)`
- the `get_or_create(username=email, ...)` seed helpers
- nomination / award reviewers are configured by username and resolved the same way

`username` was only set from `email` in `User.save()` when it was blank 
 A member who later changed their email kept the old value as their
username, and those lookups might be failing for them.

Login is unaffected: `ACCOU_LOGIN_METHODS = {"email"}`, so allauth authenticates
on the email address, not the username. The session auth hash is password-based,
so changing the username does not log anyone out.

## Changes

`User.save()` gets a small sync step:

- `from_db` records the email the row was loaded with (`_loaded_email`).
- On save, if the username currently equals that loaded email (so it was
  tracking the address) and the email has changed, `username` is set to the new
  email.
- It is skipped when:
  - the username was deliberately set to something other than the email
    `self.username != loaded_email` @VenturaFranklin Not sure if this is an edge
     case but it broke local dev and I am assuming there are other users set like this
  - the new address is longer than the 150-char `username` column.
  - another account already uses that username (would be an `IntegrityError`)
- If the caller passed `update_fields`, `"username"` is appended so the change is
  actually written -- allauth's "make primary" flow saves with
  `update_fields=["email"]`.

Every path that edits a member's email (the profile form, the reviewed
member-update flow, Django admin, `/accounts/email/`) funnels through
`User.save()`, so this covers all of them in one place.

## Tests

`thetatauCMT/users/tests/test_models.py`
- email change syncs the username
- a deliberately different username is left alone
- a would-be collision with another account is skipped (no `IntegrityError`)
- `save(update_fields=["email"])` still persists the username
- new-user creation still takes its username from the email

`thetatauCMT/users/tests/test_auth_flows.py`
- driving allauth's `/accounts/email/` "Make Primary" through the test client
  updates both `email` and `username`

Full suite green. No migration (methods only). Note the AI helped make the 
authflow test so if it needs to be changed let me know. 

## Not changed

- Users whose `username` and `email` had already drifted apart are left as-is
  the sync only acts on users whose username was tracking the email.
- `/accounts/email/` "Remove" cannot change `user.email` allauth blocks
  deleting the primary address so only "Make Primary" needed covering.
