### PR TITLE
chore(ci): Update renovate configuration to resolve warn in dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,10 @@
     "custom.regex"
   ],
   "minimumReleaseAge": "3 days",
-  "internalChecksFilter": "strict",
+  "internalChecksFilter": "flexible",
+  "vulnerabilityAlerts": {
+    "enabled": false
+  },
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## What

Two `renovate.json` changes so the base-image update flow is visible and actionable:

## Why

**`strict` -> `flexible`**

With `strict`, Renovate does not create a branch or PR for an update until it
has passed `minimumReleaseAge` (3 days). Held updates only show up as one-line
entries in the Dependency Dashboard issue, with no diff to review and no CI. And
because the base images are grouped, a frequently-rebuilt image keeps the whole 
group's PR from ever being created.

`flexible` keeps the same 3-day protection but surfaces it differently: Renovate
opens the branch and PR right away, and the age requirement becomes a pending
`renovate/stability-days` status check on the PR. You can see the diff, CI runs,
and the check flips to green once the release is 3 days old. 

**`vulnerabilityAlerts: { enabled: false }`**

The Dependency Dashboard shows `WARN: Cannot access vulnerability alerts`. That
feature lets Renovate label an update as fixing a known advisory, and it needs
the App's `Dependabot alerts: Read` permission. It adds little here: Renovate
only manages Docker images (there is no GitHub advisory data keyed to image
digests) and Dependabot already opens security PRs for the Python dependencies.
Disabling it removes the warning and the permission requirement.

## Follow-up

- Add `Commit statuses: Read and write` to the Renovate GitHub App. Without it,
  `flexible` still opens the PR but the `renovate/stability-days` check is not
  posted to GitHub (Renovate tracks the hold internally instead).

## Verification

`renovate-config-validator` passes.